### PR TITLE
Add information for Schools under Contact us

### DIFF
--- a/lib/en-us.coffee
+++ b/lib/en-us.coffee
@@ -152,3 +152,4 @@ module.exports =
   contact:
     contactUs: '''Contact Us'''
     contactUsMessage: '''The Penguin Watch research team is very small, and often working in the field in Antarctica! If you need to contact them, drop them a line at <a href="mailto:contact@penguinwatch.org">contact@penguinwatch.org</a> and they will try and get back to you when they can.'''
+    contactUsSchools: '''If you are a school or educational institution and would like to download one of our Penguin Watch information packs, please <a href="https://static.zooniverse.org/www.penguinwatch.org/downloads/PenguinWatch_Schools.zip">click here</a>. For further information, email <a href="mailto:schools@penguinwatch.org">schools@penguinwatch.org</a>'''

--- a/templates/team-page.coffee
+++ b/templates/team-page.coffee
@@ -72,6 +72,7 @@ module.exports = (context) ->
       <div class='contact'>
         <h2 class='readymade-team-group-title'>#{translate 'span', 'contact.contactUs'}</h2>
         <p>#{translate 'contact.contactUsMessage'}</p>
+        <p>#{translate 'contact.contactUsSchools'}</p>
       </div>
     </div>
   "


### PR DESCRIPTION
## PR Overview
* Under the Team -> Contact Us section, some new information for schools has been added. This includes a link to a 'content/information pack for schools'.
* NOTE: A massive 2GB Zip file was added to https://www.penguinwatch.org/downloads/ ; this was manually done separately from this PR. 